### PR TITLE
Increase client body size for all review apps.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VER
 
 COPY network_internal.conf /etc/nginx/
 
+COPY custom-nginx.conf /etc/nginx/conf.d/custom-nginx.conf
+
 COPY . /app/
 WORKDIR /app/
 

--- a/custom-nginx.conf
+++ b/custom-nginx.conf
@@ -1,0 +1,3 @@
+# All all endpoints for all virtual hosts to
+# make requests with large bodies.
+client_max_body_size 1024m;


### PR DESCRIPTION
Review apps consistently run into issues because the default
limit is quite small.